### PR TITLE
BTree prototype: format code and add option for PCH

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -6,6 +6,7 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
                                              "MinSizeRel" "RelWithDebInfo")
 
 option(USE_LLD "Use lld instead of ld for linking" OFF)
+option(ENABLE_PCH "Enable precompiled header" ON)
 option(ENABLE_TESTING "Enable Google test" ON)
 option(ENABLE_WARNING "Enable compiler warnings" ON)
 option(WARNING_AS_ERROR "Change compiler warnings to errors" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,19 @@
 add_library(b-tree INTERFACE)
 target_link_libraries(b-tree INTERFACE compile-opts)
 target_include_directories(b-tree INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(ENABLE_PCH)
+    target_precompile_headers(
+        b-tree
+        INTERFACE
+        <array>
+        <cassert>
+        <climits>
+        <concepts>
+        <cstddef>
+        <memory>
+        <optional>
+        <stdexcept>
+        <type_traits>
+        <utility>)
+endif()

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -519,7 +519,7 @@ template <Key K, std::size_t MIN_DEG> class BTree {
      */
     auto operator=(const BTree& cpy) noexcept -> BTree& {
         if (&cpy == this) {
-          return *this;
+            return *this;
         }
         // root_ always has value
         BTreeNode<K, MIN_DEG> copy_root = *cpy.root_.get();


### PR DESCRIPTION
(as the PR name says)

PCH is enabled by default, and precompile "standard" headers (eg, <arrays>).