### PR TITLE
BTree: feat: add option for precompiled header

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -6,6 +6,7 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
                                              "MinSizeRel" "RelWithDebInfo")
 
 option(USE_LLD "Use lld instead of ld for linking" OFF)
+option(ENABLE_PCH "Enable precompiled header" ON)
 option(ENABLE_TESTING "Enable Google test" ON)
 option(ENABLE_WARNING "Enable compiler warnings" ON)
 option(WARNING_AS_ERROR "Change compiler warnings to errors" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,19 @@
 add_library(b-tree INTERFACE)
 target_link_libraries(b-tree INTERFACE compile-opts)
 target_include_directories(b-tree INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(ENABLE_PCH)
+    target_precompile_headers(
+        b-tree
+        INTERFACE
+        <array>
+        <cassert>
+        <climits>
+        <concepts>
+        <cstddef>
+        <memory>
+        <optional>
+        <stdexcept>
+        <type_traits>
+        <utility>)
+endif()


### PR DESCRIPTION
PCH is on by default. Precompile standard library headers.

commit-by: Huy Nguyen