### PR TITLE
Finish remove method

### DIFF
--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -124,21 +124,21 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     /**
      * Only call when this node has left neighbour
      *
-     * @return Non-owning pointer to left neighbour
+     * @return Non-owning reference to left neighbour
      */
-    [[nodiscard]] auto get_left_() noexcept -> BTreeNode* {
+    [[nodiscard]] auto get_left_() noexcept -> BTreeNode& {
         assert(has_left_());
-        return parent_->children_[index_ - 1].get();
+        return *parent_->children_[index_ - 1].get();
     }
 
     /**
      * Only call when this node has right neighbour
      *
-     * @return Non-owning pointer to right neighbour
+     * @return Non-owning reference to right neighbour
      */
-    [[nodiscard]] auto get_right_() noexcept -> BTreeNode* {
+    [[nodiscard]] auto get_right_() noexcept -> BTreeNode& {
         assert(has_right_());
-        return parent_->children_[index_ + 1].get();
+        return *parent_->children_[index_ + 1].get();
     }
 
     /**
@@ -214,7 +214,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @param curr_bt
      */
-    void inner_split_(BTree<K, MIN_DEG>* curr_bt, K& new_key);
+    void inner_split_(BTree<K, MIN_DEG>& curr_bt, K& new_key);
     /**
      * @brief Inserts the specified child at the specified index.
      *
@@ -247,7 +247,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param key The specified key
      * @param index The specified index
      */
-    void inner_insert_key_at_(BTree<K, MIN_DEG>* curr_bt,
+    void inner_insert_key_at_(BTree<K, MIN_DEG>& curr_bt,
                               std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key,
                               std::size_t index);
     /**
@@ -261,7 +261,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @param key The specified key.
      */
-    void inner_insert_(BTree<K, MIN_DEG>* curr_bt,
+    void inner_insert_(BTree<K, MIN_DEG>& curr_bt,
                        std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key);
 
     /**
@@ -273,7 +273,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param key The specified key
      * @return true if key exists (and is removed), false if key doesn't exist.
      */
-    auto leaf_remove_(BTree<K, MIN_DEG>* curr_bt,
+    auto leaf_remove_(BTree<K, MIN_DEG>& curr_bt,
                       std::conditional_t<CAN_TRIVIAL_COPY_, K, const K&>
                           key) noexcept -> bool;
 
@@ -287,7 +287,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * rebalancing (specifically, merging), the newly merged node is the new
      * root.
      */
-    void leaf_rebalance_(BTree<K, MIN_DEG>* curr_bt) noexcept;
+    void leaf_rebalance_(BTree<K, MIN_DEG>& curr_bt) noexcept;
 
     /**
      * @brief Either borrow from left or right, or merge.
@@ -407,7 +407,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * its right neighbour cannot remove any more keys without going below the
      * minimum degree.
      */
-    void leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexcept;
+    void leaf_merge_right_(BTree<K, MIN_DEG>& curr_bt) noexcept;
 
     /**
      * @brief Merge this node with its right neighbour
@@ -416,7 +416,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * its right neighbour cannot remove any more keys without going below the
      * minimum degree.
      */
-    void nonleaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexcept;
+    void nonleaf_merge_right_(BTree<K, MIN_DEG>& curr_bt) noexcept;
 
   public:
     BTreeNode() noexcept = default;
@@ -724,7 +724,7 @@ auto BTreeNode<K, MIN_DEG>::find_(
 }
 
 template <Key K, std::size_t MIN_DEG>
-void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>* curr_bt,
+void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>& curr_bt,
                                          K& new_key) {
     // in case you don't listen.
     assert(is_full());
@@ -788,9 +788,9 @@ void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>* curr_bt,
                                        std::move(this->keys_[median_idx]), 0);
         --this->n_keys_;
         // curr_bt->root_ is essentially an unique_ptr to this
-        new_root->inner_insert_child_at_(std::move(curr_bt->root_), 0);
+        new_root->inner_insert_child_at_(std::move(curr_bt.root_), 0);
         new_root->inner_insert_child_at_(std::move(new_node), 1);
-        curr_bt->root_ = std::move(new_root);
+        curr_bt.root_ = std::move(new_root);
     }
 }
 
@@ -813,7 +813,7 @@ void BTreeNode<K, MIN_DEG>::inner_insert_child_at_(
 
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::inner_insert_key_at_(
-    BTree<K, MIN_DEG>* curr_bt,
+    BTree<K, MIN_DEG>& curr_bt,
     std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key, std::size_t index) {
     assert(is_full() ? index <= MAX_KEYS_ : index < MAX_KEYS_);
 
@@ -850,7 +850,7 @@ void BTreeNode<K, MIN_DEG>::inner_insert_key_at_(
 
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::inner_insert_(
-    BTree<K, MIN_DEG>* curr_bt,
+    BTree<K, MIN_DEG>& curr_bt,
     std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key) {
     bool is_split = false;
     K insert_key = std::move(key);
@@ -885,7 +885,7 @@ void BTreeNode<K, MIN_DEG>::inner_insert_(
 
 template <Key K, std::size_t MIN_DEG>
 auto BTreeNode<K, MIN_DEG>::leaf_remove_(
-    BTree<K, MIN_DEG>* curr_bt,
+    BTree<K, MIN_DEG>& curr_bt,
     std::conditional_t<CAN_TRIVIAL_COPY_, K, const K&> key) noexcept -> bool {
     assert(is_leaf());
 
@@ -903,11 +903,11 @@ auto BTreeNode<K, MIN_DEG>::leaf_remove_(
 
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::leaf_rebalance_(
-    BTree<K, MIN_DEG>* curr_bt) noexcept {
+    BTree<K, MIN_DEG>& curr_bt) noexcept {
     assert(!is_root());
     assert(is_leaf());
     assert(n_keys_ < MIN_DEG);
-    if (has_left_() && get_left_()->n_keys_ > MIN_DEG) {
+    if (has_left_() && get_left_().n_keys_ > MIN_DEG) {
         // make room for borrowed key
         for (std::size_t pos = n_keys_; pos > 0; --pos) {
             keys_[pos] = std::move(keys_[pos - 1]);
@@ -916,13 +916,13 @@ void BTreeNode<K, MIN_DEG>::leaf_rebalance_(
         ++n_keys_;
         return;
     }
-    if (has_right_() && get_right_()->n_keys_ > minimum_deg_()) {
+    if (has_right_() && get_right_().n_keys_ > minimum_deg_()) {
         keys_[n_keys_] = leaf_borrow_right_();
         ++n_keys_;
         return;
     }
     if (has_left_()) {
-        get_left_()->leaf_merge_right_(curr_bt);
+        get_left_().leaf_merge_right_(curr_bt);
         return;
     }
     this->leaf_merge_right_(curr_bt);
@@ -965,13 +965,27 @@ auto BTreeNode<K, MIN_DEG>::leaf_inner_remove_at_(std::size_t index) noexcept
 }
 
 template <Key K, std::size_t MIN_DEG>
+auto BTreeNode<K, MIN_DEG>::nonleaf_inner_remove_(
+    std::conditional_t<CAN_TRIVIAL_COPY_, K, const K&> key) noexcept -> bool {
+    assert(!is_leaf());
+
+    std::pair<bool, std::size_t> pair_result = inner_key_find_(key);
+    if (!pair_result.first) {
+        return false;
+    }
+
+    // find and get the largest element of the left subtree
+    BTreeNode* curr_node = children_[pair_result.second].get();
+}
+
+template <Key K, std::size_t MIN_DEG>
 [[nodiscard]] auto BTreeNode<K, MIN_DEG>::leaf_borrow_left_() noexcept
     -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> {
     assert(has_left_());
 
-    BTreeNode* left = get_left_();
+    BTreeNode& left = get_left_();
     K ret = std::move(parent_->keys_[index_ - 1]);
-    parent_->keys_[index_ - 1] = left->leaf_inner_remove_at_(left->n_keys_ - 1);
+    parent_->keys_[index_ - 1] = left.leaf_inner_remove_at_(left.n_keys_ - 1);
 
     return ret;
 }
@@ -981,17 +995,17 @@ template <Key K, std::size_t MIN_DEG>
     -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> {
     assert(has_right_());
 
-    BTreeNode* right = get_right_();
+    BTreeNode& right = get_right_();
     K ret = std::move(parent_->keys_[index_]);
-    parent_->keys_[index_] = right->leaf_inner_remove_at_(0);
+    parent_->keys_[index_] = right.leaf_inner_remove_at_(0);
 
     return ret;
 }
 
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::leaf_merge_right_(
-    BTree<K, MIN_DEG>* curr_bt) noexcept {
-    assert(has_right_() && get_right_()->n_keys_ <= MIN_DEG);
+    BTree<K, MIN_DEG>& curr_bt) noexcept {
+    assert(has_right_() && get_right_().n_keys_ <= MIN_DEG);
 
     keys_[n_keys_] = std::move(parent_->keys_[this->index_]);
     ++n_keys_;
@@ -1015,9 +1029,9 @@ void BTreeNode<K, MIN_DEG>::leaf_merge_right_(
     }
 
     if (parent_->is_root() && parent_->n_keys_ == 0) {
-        curr_bt->root_ = std::move(curr_bt->root_->children_[index_]);
-        curr_bt->root_->parent_ = nullptr;
-        curr_bt->root_->index_ = 0;
+        curr_bt.root_ = std::move(curr_bt.root_->children_[index_]);
+        curr_bt.root_->parent_ = nullptr;
+        curr_bt.root_->index_ = 0;
     }
 }
 
@@ -1039,7 +1053,7 @@ auto BTree<K, MIN_DEG>::insert(
     }
     auto index = static_cast<std::size_t>(
         static_cast<long long>(pair_result.second) + 1);
-    curr_node->inner_insert_key_at_(this, std::forward<K>(key), index);
+    curr_node->inner_insert_key_at_(*this, std::forward<K>(key), index);
     return true;
 }
 
@@ -1062,7 +1076,7 @@ auto BTree<K, MIN_DEG>::remove(
     if (!pair_result.first) {
         return false;
     }
-    curr_node->leaf_remove_(this, key);
+    curr_node->leaf_remove_(*this, key);
     return true;
 }
 } // namespace my_b_tree

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -1255,8 +1255,6 @@ auto BTree<K, MIN_DEG>::remove(
     std::pair<bool, std::size_t> pair_result = curr_node->inner_key_find_(key);
     while (!curr_node->is_leaf()) {
         if (pair_result.first) {
-            // TODO: change this after a non-leaf remove method has been
-            // implemented
             curr_node->nonleaf_remove_at_(*this, pair_result.second);
             return true;
         }

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -595,7 +595,7 @@ template <Key K, std::size_t MIN_DEG> class BTree {
      * moved).
      */
     auto insert(std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>
-                    key) noexcept -> bool;
+                    key) -> bool;
     /**
      * @brief Inserts the specified key into the BTree.
      *
@@ -1023,7 +1023,7 @@ void BTreeNode<K, MIN_DEG>::leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexce
 
 template <Key K, std::size_t MIN_DEG>
 auto BTree<K, MIN_DEG>::insert(
-    std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&> key) noexcept
+    std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&> key) 
     -> bool {
     BTreeNode<K, MIN_DEG>* curr_node = root_.get();
 

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -88,6 +88,8 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
 
     /**
      * @brief This node's position inside parent's children pointer array
+     *
+     * When this node is root (parent_ == nullptr), index_ = 0;
      */
     std::size_t index_{0};
 
@@ -99,7 +101,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * This should only be used when the difference between root's
      * minimum degree and others' is important.
      *
-     * @return 0 if root, MIN_DEG otherwise
+     * @return 1 if root, MIN_DEG otherwise
      */
     [[nodiscard]] auto minimum_deg_() const noexcept -> std::size_t {
         return (is_root()) ? 1 : MIN_DEG;
@@ -286,10 +288,6 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
 
     /**
      * @brief Either borrow from left or right, or merge.
-     *
-     * The difference to leaf_rebalance is this method also
-     * borrows (more like, own) the corresponding child from
-     * the borrowed node.
      *
      * Must only be called when n_keys_ <= minimum_deg_(),
      * which also means this node should not be root.

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -159,7 +159,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * 1. This node has a parent (aka, is not root).
      * 2. This node has a right neighbour.
      *
-     * @return An unique pointer to this node's left neighbour 
+     * @return An unique pointer to this node's left neighbour
      */
     auto own_left_neighbour_() -> std::unique_ptr<BTreeNode>&& {
         assert(has_left_neighbour_());
@@ -171,7 +171,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * 1. This node has a parent (aka, is not root).
      * 2. This node has a right neighbour.
      *
-     * @return An unique pointer to this node's left neighbour 
+     * @return An unique pointer to this node's left neighbour
      */
     auto own_right_neighbour_() -> std::unique_ptr<BTreeNode>&& {
         assert(has_right_neighbour_());
@@ -345,7 +345,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return The old separator.
      */
-    auto borrow_left_()
+    [[nodiscard]] auto borrow_left_()
         -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
     /**
      * @brief Takes the separator between this node and its right neighbour, and
@@ -363,7 +363,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return The old separator.
      */
-    auto borrow_right_()
+    [[nodiscard]] auto borrow_right_()
         -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
 
     /**

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -267,6 +267,177 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     inner_insert_(BTree<K, MIN_DEG>* curr_bt,
                   std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key) noexcept;
 
+    /**
+     * @brief Takes the separator between this node and its left neighbour, and
+     * take the left child's largest key to be the new separator.
+     *
+     * Must only be called when:
+     * 1. There exists a left neighbour.
+     * 2. The left neighbour's number of keys is at least one more than the
+     * minimum degree.
+     * 3. This node (and consequently its left neighbour) is not root (aka, has
+     * parent).
+     *
+     * If a node cannot borrow from both its left and right neighbour, a merge
+     * is triggered.
+     *
+     * @return The old separator.
+     */
+    auto borrow_left_()
+        -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
+    /**
+     * @brief Takes the separator between this node and its right neighbour, and
+     * take the right child's smallest key to be the new separator.
+     *
+     * Must only be called when:
+     * 1. There exists a right neighbour.
+     * 2. The right neigbbour's number of keys is at least one more than the
+     * minimum degree.
+     * 3. This node (and consequently its right neighbour) is not root (aka, has
+     * parent).
+     *
+     * If a node cannot borrow from both its left and right neighbour, a merge
+     * is triggered.
+     *
+     * @return The old separator.
+     */
+    auto borrow_right_()
+        -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
+
+    /**
+     * @brief Merge with the node right of this node.
+     *
+     * The new node's key layout is the following:
+     * [keys of this] [separator] [keys of right]
+     *
+     * Must only be called when:
+     * 1. This node (and its right neighbour consequently) are leaves.
+     * 2. This node has a right neighbour (aka, this->index_ <
+     * parent->n_children_ - 1)
+     * 3. Both this node and its right neighbour are at or below minimum degree.
+     *
+     * The current BTree is passed in, in the case this causes a merge happening
+     * when the root only has 1 key left, so a new root is updated.
+     */
+    void leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt);
+
+    /**
+     * @brief Merge with the node right of this node.
+     *
+     * The new node's key layout is the following:
+     * [keys of this] [separator] [keys of right]
+     *
+     * The new node's children layout is the following:
+     * [children of this] [children of right]
+     *
+     * Must only be called when:
+     * 1. This node (and its right neighbour consequently) are NOT leaves.
+     * 2. This node has a right neighbour (aka, this->index_ <
+     * parent->n_children_ - 1)
+     * 3. Both this node and its right neighbour are at or below minimum degree.
+     *
+     * If this and the right neighbour's parent is the tree root, curr_bt->root_
+     * is updated to the new node.
+     *
+     * The current BTree is passed in, in the case this causes a merge happening
+     * when the root only has 1 key left, so a new root is updated.
+     *
+     * @param curr_bt
+     */
+    void nonleaf_merge_right_(BTree<K, MIN_DEG>* curr_bt);
+
+    /**
+     * @brief
+     * @return
+     */
+    auto get_left_separator_()
+        -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
+
+    /**
+     * @brief
+     * @return
+     */
+    auto get_right_separator_()
+        -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
+
+    /**
+     * @brief Removes the key at the specified index.
+     *
+     * Will trigger borrowing if removal causes the number of keys to fall below
+     * its minimum degree.
+     *
+     * If a node cannot borrow from both its left and right neighbour, a merge
+     * is triggered.
+     *
+     * Must only be called when:
+     * 1. index is in bound 0 to this->n_keys_ - 1
+     * 2. This node is leaf.
+     *
+     * @param index The specified index.
+     * @return The removed key.
+     */
+    auto leaf_remove_at_(std::size_t index)
+        -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
+
+    /**
+     * @brief Removes the key with the specified value
+     *
+     * Will trigger borrowing if removal causes the number of keys to fall below
+     * its minimum degree.
+     *
+     * If a node cannot borrow from both its left and right neighbour, a merge
+     * is triggered.
+     *
+     * Must only be called when:
+     * 1. This node is leaf.
+     *
+     * @param key The specified key.
+     * @return The removed key, if it exists, or nullopt otherwise.
+     */
+    auto leaf_remove_(
+        std::conditional_t<std::is_trivially_copyable_v<K>, K, const K&> key)
+        -> std::optional<
+            std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>>;
+
+    /**
+     * @brief Removes the key at the specified index.
+     *
+     * Will trigger borrowing if removal causes the number of keys to fall below
+     * its minimum degree.
+     *
+     * If a node cannot borrow from both its left and right neighbour, a merge
+     * is triggered.
+     *
+     * Must only be called when:
+     * 1. index is in bound 0 to this->n_keys_ - 1
+     * 2. This node is NOT leaf.
+     *
+     * @param index The specified index.
+     * @return The removed key.
+     */
+    auto nonleaf_remove_at_(std::size_t index)
+        -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
+
+    /**
+     * @brief Removes the key with the specified value
+     *
+     * Will trigger borrowing if removal causes the number of keys to fall below
+     * its minimum degree.
+     *
+     * If a node cannot borrow from both its left and right neighbour, a merge
+     * is triggered.
+     *
+     * Must only be called when:
+     * 1. This node is NOT leaf.
+     *
+     * @param key The specified key.
+     * @return The removed key, if it exists, or nullopt otherwise.
+     */
+    auto nonleaf_remove_(
+        std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&> key)
+        -> std::optional<
+            std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>>;
+
   public:
     BTreeNode() noexcept = default;
 

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -256,9 +256,8 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @param key The specified key.
      */
-    void
-    inner_insert_(BTree<K, MIN_DEG>* curr_bt,
-                  std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key);
+    void inner_insert_(BTree<K, MIN_DEG>* curr_bt,
+                       std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key);
 
     /**
      * @brief Remove the specified key out of this leaf's key array
@@ -359,8 +358,8 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return the old separator
      */
-    [[nodiscard]] auto
-    leaf_borrow_left_() noexcept -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
+    [[nodiscard]] auto leaf_borrow_left_() noexcept
+        -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
      * @brief Take the right neighbour's smallest key as the new separator
@@ -370,8 +369,8 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return the old separator
      */
-    [[nodiscard]] auto
-    leaf_borrow_right_() noexcept -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
+    [[nodiscard]] auto leaf_borrow_right_() noexcept
+        -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
      * @brief Take the left neighbour's largest key and the child larger than
@@ -594,8 +593,8 @@ template <Key K, std::size_t MIN_DEG> class BTree {
      * original variable K passed in would still be intact (aka, not actually
      * moved).
      */
-    auto insert(std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>
-                    key) -> bool;
+    auto insert(std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&> key)
+        -> bool;
     /**
      * @brief Inserts the specified key into the BTree.
      *
@@ -815,8 +814,7 @@ void BTreeNode<K, MIN_DEG>::inner_insert_child_at_(
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::inner_insert_key_at_(
     BTree<K, MIN_DEG>* curr_bt,
-    std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key,
-    std::size_t index) {
+    std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key, std::size_t index) {
     assert(is_full() ? index <= MAX_KEYS_ : index < MAX_KEYS_);
 
     bool is_split = false;
@@ -904,7 +902,8 @@ auto BTreeNode<K, MIN_DEG>::leaf_remove_(
 }
 
 template <Key K, std::size_t MIN_DEG>
-void BTreeNode<K, MIN_DEG>::leaf_rebalance_(BTree<K, MIN_DEG>* curr_bt) noexcept {
+void BTreeNode<K, MIN_DEG>::leaf_rebalance_(
+    BTree<K, MIN_DEG>* curr_bt) noexcept {
     assert(!is_root());
     assert(is_leaf());
     assert(n_keys_ < MIN_DEG);
@@ -990,7 +989,8 @@ template <Key K, std::size_t MIN_DEG>
 }
 
 template <Key K, std::size_t MIN_DEG>
-void BTreeNode<K, MIN_DEG>::leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexcept {
+void BTreeNode<K, MIN_DEG>::leaf_merge_right_(
+    BTree<K, MIN_DEG>* curr_bt) noexcept {
     assert(has_right_() && get_right_()->n_keys_ <= MIN_DEG);
 
     keys_[n_keys_] = std::move(parent_->keys_[this->index_]);
@@ -1023,8 +1023,7 @@ void BTreeNode<K, MIN_DEG>::leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexce
 
 template <Key K, std::size_t MIN_DEG>
 auto BTree<K, MIN_DEG>::insert(
-    std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&> key) 
-    -> bool {
+    std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&> key) -> bool {
     BTreeNode<K, MIN_DEG>* curr_node = root_.get();
 
     std::pair<bool, std::size_t> pair_result = curr_node->inner_key_find_(key);

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -424,11 +424,13 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
 
     /**
      * @return A pair whose:
-     * - First value is the right neighbour
-     * - Second value is the separator between this node and the right separator's
+     * - First value is the owning pointer to the right neighbour
+     * - Second value is the separator between this node and the right
+     * separator's
      */
     auto get_right_neighbour_and_sep_()
-        -> std::pair<std::unique_ptr<BTreeNode<K, MIN_DEG>&&>,
+        -> std::pair<
+            std::unique_ptr<BTreeNode<K, MIN_DEG>&&>,
             std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>>;
 
     /**
@@ -707,6 +709,9 @@ template <Key K, std::size_t MIN_DEG> class BTree {
         K pass_in = key;
         return insert(std::move(pass_in));
     }
+
+    auto remove(std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>
+                    key) noexcept -> decltype(key);
 };
 
 template <Key K, std::size_t MIN_DEG>

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -440,7 +440,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     /**
      * WARNING: VERY EXPENSIVE OPERATION.
      */
-    auto operator=(const BTreeNode& cpy) noexcept -> BTreeNode&;
+    auto operator=(const BTreeNode& cpy) -> BTreeNode&;
 
     ~BTreeNode() noexcept = default;
 
@@ -532,7 +532,7 @@ template <Key K, std::size_t MIN_DEG> class BTree {
     /**
      * WARNING: VERY EXPENSIVE OPERATION.
      */
-    auto operator=(const BTree& cpy) noexcept -> BTree& {
+    auto operator=(const BTree& cpy) -> BTree& {
         if (&cpy == this) {
             return *this;
         }
@@ -653,7 +653,7 @@ BTreeNode<K, MIN_DEG>::BTreeNode(const BTreeNode& cpy)
 }
 
 template <Key K, std::size_t MIN_DEG>
-auto BTreeNode<K, MIN_DEG>::operator=(const BTreeNode& cpy) noexcept
+auto BTreeNode<K, MIN_DEG>::operator=(const BTreeNode& cpy)
     -> BTreeNode& {
     if (&cpy == this) {
         std::swap(this->n_keys_, this->n_keys_);

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -94,6 +94,48 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     friend class BTree<K, MIN_DEG>;
 
     /**
+     * Return the technical minimum degree of the current node.
+     *
+     * This should only be used when the difference between root's
+     * minimum degree and others' is important.
+     *
+     * @return 0 if root, MIN_DEG otherwise
+     */
+    auto minimum_deg_() -> std::size_t { return (is_root()) ? 0 : MIN_DEG; }
+
+    /**
+     * @return Whether this node has a left neighbour
+     */
+    auto has_left_() -> bool { return (!is_root() && index_ > 0); }
+
+    /**
+     * @return Whether this node has a right neighbour
+     */
+    auto has_right_() -> bool {
+        return (!is_root() && index_ < parent_->n_children_ - 1);
+    }
+
+    /**
+     * Only call when this node has left neighbour
+     *
+     * @return Non-owning pointer to left neighbour
+     */
+    auto get_left_() -> BTreeNode* {
+        assert(has_left_());
+        return parent_->children_[index_ - 1].get();
+    }
+
+    /**
+     * Only call when this node has right neighbour
+     *
+     * @return Non-owning pointer to right neighbour
+     */
+    auto get_right_() -> BTreeNode* {
+        assert(has_right_());
+        return parent_->children_[index_ + 1].get();
+    }
+
+    /**
      * @brief Sets parent of this node to be the specified node.
      *
      * This is the preferred (albeit a little slower) way to change parent node.

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -101,17 +101,21 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return 0 if root, MIN_DEG otherwise
      */
-    auto minimum_deg_() -> std::size_t { return (is_root()) ? 1 : MIN_DEG; }
+    [[nodiscard]] auto minimum_deg_() const noexcept -> std::size_t {
+        return (is_root()) ? 1 : MIN_DEG;
+    }
 
     /**
      * @return Whether this node has a left neighbour
      */
-    auto has_left_() -> bool { return (!is_root() && index_ > 0); }
+    [[nodiscard]] auto has_left_() const noexcept -> bool {
+        return (!is_root() && index_ > 0);
+    }
 
     /**
      * @return Whether this node has a right neighbour
      */
-    auto has_right_() -> bool {
+    [[nodiscard]] auto has_right_() const noexcept -> bool {
         return (!is_root() && index_ < parent_->n_children_ - 1);
     }
 
@@ -120,7 +124,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return Non-owning pointer to left neighbour
      */
-    auto get_left_() -> BTreeNode* {
+    [[nodiscard]] auto get_left_() noexcept -> BTreeNode* {
         assert(has_left_());
         return parent_->children_[index_ - 1].get();
     }
@@ -130,7 +134,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return Non-owning pointer to right neighbour
      */
-    auto get_right_() -> BTreeNode* {
+    [[nodiscard]] auto get_right_() noexcept -> BTreeNode* {
         assert(has_right_());
         return parent_->children_[index_ + 1].get();
     }
@@ -145,7 +149,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param parent The specified parent node.
      * @param index The specified index.
      */
-    void set_parent_(BTreeNode* parent, std::size_t index) {
+    void set_parent_(BTreeNode* parent, std::size_t index) noexcept {
         // in case you don't listen
         assert(parent != this);
         assert(index < MAX_CHILDREN_);
@@ -159,7 +163,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * index must be between 0 and MAX_CHILDREN_
      */
-    void set_index_(std::size_t index) {
+    void set_index_(std::size_t index) noexcept {
         // in case you don't listen
         assert(index > 0 && index < MAX_CHILDREN_);
         index_ = index;
@@ -205,7 +209,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @param curr_bt
      */
-    void inner_split_(BTree<K, MIN_DEG>* curr_bt, K& new_key) noexcept;
+    void inner_split_(BTree<K, MIN_DEG>* curr_bt, K& new_key);
     /**
      * @brief Inserts the specified child at the specified index.
      *
@@ -218,7 +222,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param index The specified index
      */
     void inner_insert_child_at_(std::unique_ptr<BTreeNode>&& child,
-                                std::size_t index) noexcept;
+                                std::size_t index);
     /**
      * @brief Inserts the specified key to the specified position in this node's
      * inner array if this node's inner array is not yet full.
@@ -240,7 +244,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      */
     void inner_insert_key_at_(BTree<K, MIN_DEG>* curr_bt,
                               std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key,
-                              std::size_t index) noexcept;
+                              std::size_t index);
     /**
      * @brief Search for the position inside this node's inner array to insert
      * the specified key, then insert it if this node is not yet full.
@@ -254,7 +258,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      */
     void
     inner_insert_(BTree<K, MIN_DEG>* curr_bt,
-                  std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key) noexcept;
+                  std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key);
 
     /**
      * @brief Remove the specified key out of this leaf's key array
@@ -279,7 +283,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * rebalancing (specifically, merging), the newly merged node is the new
      * root.
      */
-    void leaf_rebalance_(BTree<K, MIN_DEG>* curr_bt);
+    void leaf_rebalance_(BTree<K, MIN_DEG>* curr_bt) noexcept;
 
     /**
      * @brief Either borrow from left or right, or merge.
@@ -295,7 +299,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * rebalancing (specifically, merging), the newly merged node is the new
      * root.
      */
-    void nonleaf_rebalance_(BTree<K, MIN_DEG>* curr_bt);
+    void nonleaf_rebalance_(BTree<K, MIN_DEG>* curr_bt) noexcept;
 
     /**
      * @brief Remove the specified key out of the inner array.
@@ -314,7 +318,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param index The specified index
      * @return the removed key
      */
-    auto leaf_inner_remove_at_(std::size_t index)
+    auto leaf_inner_remove_at_(std::size_t index) noexcept
         -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
@@ -344,7 +348,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param index The specified index
      * @return the removed key
      */
-    auto nonleaf_inner_remove_at_(std::size_t index)
+    auto nonleaf_inner_remove_at_(std::size_t index) noexcept
         -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
@@ -356,7 +360,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @return the old separator
      */
     [[nodiscard]] auto
-    leaf_borrow_left_() -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
+    leaf_borrow_left_() noexcept -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
      * @brief Take the right neighbour's smallest key as the new separator
@@ -367,7 +371,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @return the old separator
      */
     [[nodiscard]] auto
-    leaf_borrow_right_() -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
+    leaf_borrow_right_() noexcept -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
      * @brief Take the left neighbour's largest key and the child larger than
@@ -379,7 +383,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * - Second value is the owning pointer to the largest child of the left
      * node.
      */
-    [[nodiscard]] auto nonleaf_borrow_left_()
+    [[nodiscard]] auto nonleaf_borrow_left_() noexcept
         -> std::pair<std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>,
                      std::unique_ptr<BTreeNode<K, MIN_DEG>>>;
 
@@ -393,7 +397,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * - Second value is the owning pointer to the smallest child of the right
      * node.
      */
-    [[nodiscard]] auto nonleaf_borrow_right_()
+    [[nodiscard]] auto nonleaf_borrow_right_() noexcept
         -> std::pair<std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>,
                      std::unique_ptr<BTreeNode<K, MIN_DEG>>>;
     /**
@@ -403,7 +407,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * its right neighbour cannot remove any more keys without going below the
      * minimum degree.
      */
-    void leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt);
+    void leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexcept;
 
     /**
      * @brief Merge this node with its right neighbour
@@ -412,7 +416,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * its right neighbour cannot remove any more keys without going below the
      * minimum degree.
      */
-    void nonleaf_merge_right_(BTree<K, MIN_DEG>* curr_bt);
+    void nonleaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexcept;
 
   public:
     BTreeNode() noexcept = default;
@@ -722,7 +726,7 @@ auto BTreeNode<K, MIN_DEG>::find_(
 
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>* curr_bt,
-                                         K& new_key) noexcept {
+                                         K& new_key) {
     // in case you don't listen.
     assert(is_full());
 
@@ -793,7 +797,7 @@ void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>* curr_bt,
 
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::inner_insert_child_at_(
-    std::unique_ptr<BTreeNode>&& child, std::size_t index) noexcept {
+    std::unique_ptr<BTreeNode>&& child, std::size_t index) {
     assert(n_children_ < MAX_CHILDREN_);
     assert(child.get() != nullptr);
     assert(index < MAX_CHILDREN_);
@@ -812,7 +816,7 @@ template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::inner_insert_key_at_(
     BTree<K, MIN_DEG>* curr_bt,
     std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key,
-    std::size_t index) noexcept {
+    std::size_t index) {
     assert(is_full() ? index <= MAX_KEYS_ : index < MAX_KEYS_);
 
     bool is_split = false;
@@ -849,7 +853,7 @@ void BTreeNode<K, MIN_DEG>::inner_insert_key_at_(
 template <Key K, std::size_t MIN_DEG>
 void BTreeNode<K, MIN_DEG>::inner_insert_(
     BTree<K, MIN_DEG>* curr_bt,
-    std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key) noexcept {
+    std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key) {
     bool is_split = false;
     K insert_key = std::move(key);
     if (is_full()) {
@@ -900,7 +904,7 @@ auto BTreeNode<K, MIN_DEG>::leaf_remove_(
 }
 
 template <Key K, std::size_t MIN_DEG>
-void BTreeNode<K, MIN_DEG>::leaf_rebalance_(BTree<K, MIN_DEG>* curr_bt) {
+void BTreeNode<K, MIN_DEG>::leaf_rebalance_(BTree<K, MIN_DEG>* curr_bt) noexcept {
     assert(!is_root());
     assert(is_leaf());
     assert(n_keys_ < MIN_DEG);
@@ -946,7 +950,7 @@ auto BTreeNode<K, MIN_DEG>::leaf_inner_remove_(
 }
 
 template <Key K, std::size_t MIN_DEG>
-auto BTreeNode<K, MIN_DEG>::leaf_inner_remove_at_(std::size_t index)
+auto BTreeNode<K, MIN_DEG>::leaf_inner_remove_at_(std::size_t index) noexcept
     -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> {
     assert(index < n_keys_);
 
@@ -962,7 +966,7 @@ auto BTreeNode<K, MIN_DEG>::leaf_inner_remove_at_(std::size_t index)
 }
 
 template <Key K, std::size_t MIN_DEG>
-[[nodiscard]] auto BTreeNode<K, MIN_DEG>::leaf_borrow_left_()
+[[nodiscard]] auto BTreeNode<K, MIN_DEG>::leaf_borrow_left_() noexcept
     -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> {
     assert(has_left_());
 
@@ -974,7 +978,7 @@ template <Key K, std::size_t MIN_DEG>
 }
 
 template <Key K, std::size_t MIN_DEG>
-[[nodiscard]] auto BTreeNode<K, MIN_DEG>::leaf_borrow_right_()
+[[nodiscard]] auto BTreeNode<K, MIN_DEG>::leaf_borrow_right_() noexcept
     -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> {
     assert(has_right_());
 
@@ -986,7 +990,7 @@ template <Key K, std::size_t MIN_DEG>
 }
 
 template <Key K, std::size_t MIN_DEG>
-void BTreeNode<K, MIN_DEG>::leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) {
+void BTreeNode<K, MIN_DEG>::leaf_merge_right_(BTree<K, MIN_DEG>* curr_bt) noexcept {
     assert(has_right_() && get_right_()->n_keys_ <= MIN_DEG);
 
     keys_[n_keys_] = std::move(parent_->keys_[this->index_]);

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -545,10 +545,15 @@ void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>* curr_bt,
         // each of those key to the new node.
         for (std::size_t this_idx = median_idx + 1; this_idx <= max_idx;
              ++this_idx) {
-            new_node->inner_insert_key_at_(
-                curr_bt, std::forward<K>(this->keys_[this_idx]), new_node_idx);
-            new_node->inner_insert_child_at_(
-                std::move(this->children_[this_idx + 1]), new_node_idx + 1);
+            new_node->keys_[new_node_idx] = std::move(this->keys_[this_idx]);
+            ++new_node->n_keys_;
+
+            new_node->children_[new_node_idx + 1] =
+                std::move(this->children_[this_idx + 1]);
+            new_node->children_[new_node_idx + 1]->index_ = new_node_idx + 1;
+            new_node->children_[new_node_idx + 1]->parent_ = new_node.get();
+            ++new_node->n_children_;
+
             --this->n_keys_;
             --this->n_children_;
             ++new_node_idx;

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -256,6 +256,57 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     inner_insert_(BTree<K, MIN_DEG>* curr_bt,
                   std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key) noexcept;
 
+    auto leaf_remove_(std::conditional_t<CAN_TRIVIAL_COPY_, K, const K&>
+                          key) noexcept -> bool;
+
+    /**
+     * @brief Remove the specified key out of the inner array.
+     *
+     * @param key The specified key
+     * @return true if the key exists (and is removed), false if the key doesn't
+     */
+    auto leaf_inner_remove_(std::conditional_t<CAN_TRIVIAL_COPY_, K, const K&>
+                                key) noexcept -> bool;
+
+    /**
+     * @brief Remove the key at the specified index out of the inner array.
+     *
+     * index must be between 0 and n_keys_
+     *
+     * @param index The specified index
+     * @return the removed key
+     */
+    auto leaf_inner_remove_at_(std::size_t index) -> K;
+
+    /**
+     * @brief Take the left neighbour's largest key as the new separator between
+     * this and the left neighbour, and return the old separator.
+     *
+     * Must only be called when this is leaf and has left neighbout
+     *
+     * @return the old separator
+     */
+    auto leaf_borrow_left_() -> K;
+
+    /**
+     * @brief Take the right neighbour's smallest key as the new separator
+     * between this and the right neighbour, and return the old separator.
+     *
+     * Must only be called when this is leaf and has right neighbout
+     *
+     * @return the old separator
+     */
+    auto leaf_borrow_right_() -> K;
+
+    /**
+     * @brief Merge this node with its right neighbout
+     *
+     * Must only be called when this is leaf and both this and
+     * its right neighbour cannot remove any more keys without going below the
+     * minimum degree.
+     */
+    void leaf_merge_right_();
+
   public:
     BTreeNode() noexcept = default;
 

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -612,7 +612,7 @@ template <Key K, std::size_t MIN_DEG> class BTree {
     auto
     insert_copy(std::conditional_t<std::is_trivially_copyable_v<K>, K, const K&>
                     key) noexcept
-        -> std::enable_if_t<std::is_copy_constructible_v<K>, bool> {
+        -> std::enable_if_t<std::is_copy_assignable_v<K>, bool> {
         K pass_in = key;
         return insert(std::move(pass_in));
     }

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -202,10 +202,13 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
         -> std::optional<std::pair<const BTreeNode*, std::size_t>>;
 
     /**
-     * @brief (Simply) split the current node into 2, and insert the current
-     * median into the parent.
+     * @brief (Simply) split the current node into 2, and insert the median into
+     * the parent.
      *
      * Should only be called when this node is full.
+     *
+     * In case new_key is the median, new_key is swapped with the key that would
+     * have been the median had new_key not been.
      *
      * In case a new root node is made, curr_bt->root_ is updated.
      *
@@ -732,9 +735,12 @@ void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>* curr_bt,
     std::size_t new_node_idx = 0;
     auto new_node = std::make_unique<BTreeNode>(this->parent_);
 
+    // determine the *true* median.
     if (new_key > this->keys_[median_idx + 1]) {
         ++median_idx;
     } else if (new_key > this->keys_[median_idx]) {
+        // the new key is the median.
+        // swap the new key with the old median.
         K temp = std::move(this->keys_[median_idx]);
         this->keys_[median_idx] = std::move(new_key);
         new_key = std::move(temp);

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -289,7 +289,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @brief Take the left neighbour's largest key as the new separator between
      * this and the left neighbour, and return the old separator.
      *
-     * Must only be called when this is leaf and has left neighbout
+     * Must only be called when this is leaf and has left neighbour
      *
      * @return the old separator
      */
@@ -300,7 +300,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @brief Take the right neighbour's smallest key as the new separator
      * between this and the right neighbour, and return the old separator.
      *
-     * Must only be called when this is leaf and has right neighbout
+     * Must only be called when this is leaf and has right neighbour
      *
      * @return the old separator
      */
@@ -308,7 +308,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     leaf_borrow_right_() -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
-     * @brief Merge this node with its right neighbout
+     * @brief Merge this node with its right neighbour
      *
      * Must only be called when this is leaf and both this and
      * its right neighbour cannot remove any more keys without going below the

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -345,7 +345,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return The old separator.
      */
-    [[nodiscard]] auto borrow_left_()
+    [[nodiscard]] auto leaf_borrow_left_()
         -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
     /**
      * @brief Takes the separator between this node and its right neighbour, and
@@ -363,7 +363,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return The old separator.
      */
-    [[nodiscard]] auto borrow_right_()
+    [[nodiscard]] auto leaf_borrow_right_()
         -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
 
     /**
@@ -429,7 +429,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     auto get_right_neighbour_and_sep_()
         -> std::pair<
             std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>,
-            std::unique_ptr<BTreeNode<K, MIN_DEG>>>;
+            std::unique_ptr<BTreeNode<K, MIN_DEG>&&>>;
 
     /**
      * @brief Removes the key at the specified index.
@@ -447,7 +447,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param index The specified index.
      * @return The removed key.
      */
-    auto leaf_remove_at_(std::size_t index)
+    auto leaf_remove_at_(BTree<K, MIN_DEG>* curr_bt, std::size_t index)
         -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
 
     /**

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -117,6 +117,68 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     }
 
     /**
+     * @return Whether this node has a left neighbour
+     */
+    auto has_left_neighbour_() -> bool {
+        return parent_ != nullptr && index_ > 0;
+    }
+
+    /**
+     * @return Whether this node has a right neighbour
+     */
+    auto has_right_neighbour_() -> bool {
+        return parent_ != nullptr && index_ < n_keys_ - 1;
+    }
+
+    /**
+     * Must only be called when:
+     * 1. This node has a parent (aka, is not root).
+     * 2. This node has a left neighbour.
+     *
+     * @return A reference to this node's left neighbour
+     */
+    auto ref_left_neighbour_() -> BTreeNode& {
+        assert(has_left_neighbour_());
+        return *parent_->children_[index_ - 1].get();
+    }
+
+    /**
+     * Must only be called when:
+     * 1. This node has a parent (aka, is not root).
+     * 2. This node has a right neighbour.
+     *
+     * @return A reference to this node's right neighbour
+     */
+    auto ref_right_neighbour_() -> BTreeNode& {
+        assert(has_right_neighbour_());
+        return *parent_->children_[index_ + 1].get();
+    }
+
+    /**
+     * Must only be called when:
+     * 1. This node has a parent (aka, is not root).
+     * 2. This node has a right neighbour.
+     *
+     * @return An unique pointer to this node's left neighbour 
+     */
+    auto own_left_neighbour_() -> std::unique_ptr<BTreeNode>&& {
+        assert(has_left_neighbour_());
+        return std::move(parent_->children_[index_ - 1]);
+    }
+
+    /**
+     * Must only be called when:
+     * 1. This node has a parent (aka, is not root).
+     * 2. This node has a right neighbour.
+     *
+     * @return An unique pointer to this node's left neighbour 
+     */
+    auto own_right_neighbour_() -> std::unique_ptr<BTreeNode>&& {
+        assert(has_right_neighbour_());
+        return std::move(parent_->children_[index_ + 1]);
+    }
+
+    /**
      * @brief Sets parent of this node to be the specified node.
      *
      * This is the preferred (albeit a little slower) way to change parent node.

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -384,7 +384,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      */
     [[nodiscard]] auto nonleaf_borrow_left_() noexcept
         -> std::pair<std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>,
-                     std::unique_ptr<BTreeNode<K, MIN_DEG>>>;
+                     std::unique_ptr<BTreeNode>>;
 
     /**
      * @brief Take the right neighbour's smallest key and the child smaller than
@@ -398,7 +398,7 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      */
     [[nodiscard]] auto nonleaf_borrow_right_() noexcept
         -> std::pair<std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>,
-                     std::unique_ptr<BTreeNode<K, MIN_DEG>>>;
+                     std::unique_ptr<BTreeNode>>;
     /**
      * @brief Merge this node with its right neighbour
      *

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -256,6 +256,12 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
     inner_insert_(BTree<K, MIN_DEG>* curr_bt,
                   std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&> key) noexcept;
 
+    /**
+     * @brief Remove the specified key out of this leaf's key array
+     *
+     * @param key The specified key
+     * @return true if key exists (and is removed), false if key doesn't exist.
+     */
     auto leaf_remove_(std::conditional_t<CAN_TRIVIAL_COPY_, K, const K&>
                           key) noexcept -> bool;
 
@@ -276,7 +282,8 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      * @param index The specified index
      * @return the removed key
      */
-    auto leaf_inner_remove_at_(std::size_t index) -> K;
+    auto leaf_inner_remove_at_(std::size_t index)
+        -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
      * @brief Take the left neighbour's largest key as the new separator between
@@ -286,7 +293,8 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return the old separator
      */
-    auto leaf_borrow_left_() -> K;
+    [[nodiscard]] auto
+    leaf_borrow_left_() -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
      * @brief Take the right neighbour's smallest key as the new separator
@@ -296,7 +304,8 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
      *
      * @return the old separator
      */
-    auto leaf_borrow_right_() -> K;
+    [[nodiscard]] auto
+    leaf_borrow_right_() -> std::conditional_t<CAN_TRIVIAL_COPY_, K, K&&>;
 
     /**
      * @brief Merge this node with its right neighbout

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -653,8 +653,7 @@ BTreeNode<K, MIN_DEG>::BTreeNode(const BTreeNode& cpy)
 }
 
 template <Key K, std::size_t MIN_DEG>
-auto BTreeNode<K, MIN_DEG>::operator=(const BTreeNode& cpy)
-    -> BTreeNode& {
+auto BTreeNode<K, MIN_DEG>::operator=(const BTreeNode& cpy) -> BTreeNode& {
     if (&cpy == this) {
         std::swap(this->n_keys_, this->n_keys_);
         return *this;
@@ -766,11 +765,8 @@ void BTreeNode<K, MIN_DEG>::inner_split_(BTree<K, MIN_DEG>* curr_bt,
             new_node->keys_[new_node_idx] = std::move(this->keys_[this_idx]);
             ++new_node->n_keys_;
 
-            new_node->children_[new_node_idx + 1] =
-                std::move(this->children_[this_idx + 1]);
-            new_node->children_[new_node_idx + 1]->index_ = new_node_idx + 1;
-            new_node->children_[new_node_idx + 1]->parent_ = new_node.get();
-            ++new_node->n_children_;
+            new_node->inner_insert_child_at_(
+                std::move(this->children_[this_idx + 1]), new_node_idx + 1);
 
             --this->n_keys_;
             --this->n_children_;

--- a/src/b-tree.hxx
+++ b/src/b-tree.hxx
@@ -423,13 +423,13 @@ template <Key K, std::size_t MIN_DEG> class BTreeNode {
         -> std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>;
 
     /**
-     * @brief
-     * @return
+     * @return A pair whose:
+     * - First value is the right neighbour
+     * - Second value is the separator between this node and the right separator's
      */
     auto get_right_neighbour_and_sep_()
-        -> std::pair<
-            std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>,
-            std::unique_ptr<BTreeNode<K, MIN_DEG>&&>>;
+        -> std::pair<std::unique_ptr<BTreeNode<K, MIN_DEG>&&>,
+            std::conditional_t<std::is_trivially_copyable_v<K>, K, K&&>>;
 
     /**
      * @brief Removes the key at the specified index.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,9 +29,9 @@ if(ENABLE_ASAN)
     target_link_libraries(test-exe PRIVATE asan)
 endif()
 gtest_discover_tests(test-exe)
-add_custom_command(
-    TARGET test-exe
-    POST_BUILD
-    COMMAND ${CMAKE_CTEST_COMMAND}
-    USES_TERMINAL
-    COMMENT "Run tests after compilation")
+# add_custom_command(
+#     TARGET test-exe
+#     POST_BUILD
+#     COMMAND ${CMAKE_CTEST_COMMAND}
+#     USES_TERMINAL
+#     COMMENT "Run tests after compilation")

--- a/test/test-b-tree.cxx
+++ b/test/test-b-tree.cxx
@@ -114,6 +114,17 @@ TEST(b_tree, leaf_remove) { // NOLINT
 }
 
 TEST(b_tree, nonleaf_remove) { // NOLINT
+    bt::BTree<int, 2> test_tree{};
+    for (int num = 1; num < 30; ++num) { // NOLINT
+        test_tree.insert(num);
+    }
+    // place a breakpoint on this comment to see how the tree is at this stage
+    ASSERT_TRUE(test_tree.remove(3));
+    ASSERT_FALSE(test_tree.contains(3));
+    ASSERT_TRUE(test_tree.remove(12));
+    ASSERT_FALSE(test_tree.contains(12));
+    ASSERT_TRUE(test_tree.remove(18));
+    ASSERT_FALSE(test_tree.contains(18));
 }
 
 TEST(b_tree, copy) {

--- a/test/test-b-tree.cxx
+++ b/test/test-b-tree.cxx
@@ -85,20 +85,20 @@ TEST(b_tree, leaf_remove) { // NOLINT
     }
     // current tree:
     //   [3         6]
-    //    /    |     \
+    //    
     // [1 2] [4 5]  [7 8 9 10]
     ASSERT_TRUE(test_tree.remove(1));
     ASSERT_FALSE(test_tree.find(1).has_value());
     // current tree:
     //  [   6       ]
-    //  /           \
+    //  
     // [2 3 4 5]    [7 8 9 10]
     ASSERT_TRUE(test_tree.remove(3));
     ASSERT_TRUE(test_tree.remove(7));
     ASSERT_TRUE(test_tree.remove(2));
     // current tree:
     //  [   6       ]
-    //  /           \
+    //  
     // [4 5]    [8 9 10]
     ASSERT_FALSE(test_tree.find(3).has_value());
     ASSERT_FALSE(test_tree.find(2).has_value());
@@ -106,7 +106,7 @@ TEST(b_tree, leaf_remove) { // NOLINT
     ASSERT_TRUE(test_tree.remove(4));
     // current tree:
     //  [   8     ]
-    //  /         \
+    //  
     // [5 6]    [9 10]
     ASSERT_TRUE(test_tree.remove(9));
     // current tree:

--- a/test/test-b-tree.cxx
+++ b/test/test-b-tree.cxx
@@ -93,6 +93,24 @@ TEST(b_tree, leaf_remove) { // NOLINT
     //  [   6       ]
     //  /           \
     // [2 3 4 5]    [7 8 9 10]
+    ASSERT_TRUE(test_tree.remove(3));
+    ASSERT_TRUE(test_tree.remove(7));
+    ASSERT_TRUE(test_tree.remove(2));
+    // current tree:
+    //  [   6       ]
+    //  /           \
+    // [4 5]    [8 9 10]
+    ASSERT_FALSE(test_tree.find(3).has_value());
+    ASSERT_FALSE(test_tree.find(2).has_value());
+    ASSERT_FALSE(test_tree.find(7).has_value());
+    ASSERT_TRUE(test_tree.remove(4));
+    // current tree:
+    //  [   8     ]
+    //  /         \
+    // [5 6]    [9 10]
+    ASSERT_TRUE(test_tree.remove(9));
+    // current tree:
+    // [5 6 8 10]
 }
 
 TEST(b_tree, nonleaf_remove) { // NOLINT

--- a/test/test-b-tree.cxx
+++ b/test/test-b-tree.cxx
@@ -1,9 +1,9 @@
 #include "b-tree.hxx"
+#include <concepts>
 #include <gtest/gtest.h>
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <concepts>
 
 namespace bt = my_b_tree;
 
@@ -31,10 +31,10 @@ TEST(b_tree, insert_medium_mode) { // NOLINT
     bt::BTree<int, 1> test_tree{};
     test_tree.insert(69); // NOLINT
     ASSERT_TRUE(test_tree.contains(69));
-    test_tree.insert(42); // NOLINT
-    ASSERT_TRUE(test_tree.contains(42));
     test_tree.insert(13); // NOLINT
     ASSERT_TRUE(test_tree.contains(13));
+    test_tree.insert(42); // NOLINT
+    ASSERT_TRUE(test_tree.contains(42));
     test_tree.insert(77); // NOLINT
     ASSERT_TRUE(test_tree.contains(77));
     test_tree.insert(420); // NOLINT
@@ -78,25 +78,48 @@ TEST(b_tree, insert_hard_mode) { // NOLINT
     }
 }
 
-TEST(b_tree, copy){
+TEST(b_tree, leaf_remove) { // NOLINT
+    bt::BTree<int, 2> test_tree{};
+    for (int num = 1; num < 11; ++num) { // NOLINT
+        test_tree.insert(num);
+    }
+    // current tree:
+    //   [3         6]
+    //    /    |     \
+    // [1 2] [4 5]  [7 8 9 10]
+    ASSERT_TRUE(test_tree.remove(1));
+    ASSERT_FALSE(test_tree.find(1).has_value());
+    // current tree:
+    //  [   6       ]
+    //  /           \
+    // [2 3 4 5]    [7 8 9 10]
+}
+
+TEST(b_tree, nonleaf_remove) { // NOLINT
+}
+
+TEST(b_tree, copy) {
     bt::BTree<int, 4> test_tree{};
-    for(int i = 0; i < 10; ++i){ // NOLINT
+    for (int i = 0; i < 10; ++i) { // NOLINT
         test_tree.insert(i);
     }
     auto copy_test_tree{test_tree};
-    for(int i = 0; i < 10; ++i){ // NOLINT
+    for (int i = 0; i < 10; ++i) { // NOLINT
         ASSERT_TRUE(copy_test_tree.contains(i));
         ASSERT_TRUE(test_tree.contains(i));
     }
+    copy_test_tree.insert(69); // NOLINT
+    ASSERT_TRUE(copy_test_tree.find(69).has_value());
+    ASSERT_FALSE(test_tree.find(69).has_value());
 }
 
-TEST(b_tree, move){
+TEST(b_tree, move) {
     bt::BTree<int, 4> test_tree{};
-    for(int i = 0; i < 10; ++i){ // NOLINT
+    for (int i = 0; i < 10; ++i) { // NOLINT
         test_tree.insert(i);
     }
     auto move_test_tree{std::move(test_tree)};
-    for(int i = 0; i < 10; ++i){ // NOLINT
+    for (int i = 0; i < 10; ++i) { // NOLINT
         ASSERT_TRUE(move_test_tree.contains(i));
     }
 }
@@ -116,4 +139,3 @@ TEST(b_tree, insert_nontrival_copy) {
     ASSERT_TRUE(test_tree.insert(std::move(another_sus))); // NOLINT
     ASSERT_STREQ(another_sus.c_str(), "");                 // NOLINT
 }
-


### PR DESCRIPTION
My goodness, this took me 3 days. Well, at least that's a lot faster than the time I had to spend writing the insert method.

There's also a small change to the insert methods. Now, instead of blindly choosing the current median (without considering the to-be-inserted key), the new key is also taken into consideration. This results in a nicer tree :). A lot nicer actually. Before this, there are cases where the newly formed left child has 0 key and child, which is bad.

Another nice touch is, a lot of the functions take in reference instead of pointer now. This ensures whatever they are taking isn't null, and we can use `.` instead of `->` for such objects.

This BTree thingy took me a grand total of 1274 lines of code to write. I think I could have shortened it by quite a bit, maybe down to 1100 or even 1000 lines, but, if it ain't broken, don't touch it.

For the main project (smoldb), we probably don't need the template. A lot of the length is due to template (concept, `std::conditional_t`, `std::enable_if`, `std::is_trivially_copyable`...). But hey, it makes the code at least easier to test.